### PR TITLE
Feat/add ocr radar cet rio

### DIFF
--- a/models/mart/ocr_radar/__sources.yml
+++ b/models/mart/ocr_radar/__sources.yml
@@ -1,0 +1,11 @@
+version: 2
+
+sources:
+  - name: ocr_radar
+    database: rj-cetrio
+    schema: ocr_radar
+    freshness: # default freshness
+      error_after: {count: 24, period: hour}
+    loaded_at_field: updated_at
+    tables:
+      - name: equipamento

--- a/models/raw/ocr_radar/__sources.yml
+++ b/models/raw/ocr_radar/__sources.yml
@@ -6,6 +6,6 @@ sources:
     schema: ocr_radar
     freshness: # default freshness
       error_after: {count: 24, period: hour}
-    loaded_at_field: updated_at
+    loaded_at_field: Cast(updated_at as DATETIME)
     tables:
       - name: equipamento


### PR DESCRIPTION
This pull request introduces a new source configuration for the OCR Radar database. The most important change is the addition of a new source definition in the `models/raw/ocr_radar/__sources.yml` file.

Configuration changes:

* [`models/raw/ocr_radar/__sources.yml`](diffhunk://#diff-f0065626834897e72bbefaec7dcfd129d88730ec79c694bea24dc34c46f0dc9bR1-R11): Added a new source definition for the `ocr_radar` database, including default freshness settings and table definitions.