### PR TITLE
refact: Remove unused column from unidades_administrativas_orgaos SQL…

### DIFF
--- a/models/raw/unidades_administrativas/raw_unidades_administrativas_orgaos.sql
+++ b/models/raw/unidades_administrativas/raw_unidades_administrativas_orgaos.sql
@@ -8,9 +8,10 @@ SELECT
   SAFE_CAST(
     REGEXP_REPLACE(nome_ua, r'\.0$', '') AS STRING
   ) as nome_unidade_administrativa,
-  SAFE_CAST(
-    REGEXP_REPLACE(cd_ua_pai, r'\.0$', '') AS STRING
-  ) as id_unidade_administrativa_pai,
+  -- SAFE_CAST(
+  --  REGEXP_REPLACE(cd_ua_pai, r'\.0$', '') AS STRING
+  -- #) as id_unidade_administrativa_pai,
+  -- COLUMN REMOVED FROM SCHEMA
   SAFE_CAST(
     REGEXP_REPLACE(nivel, r'\.0$', '') AS STRING
   ) as nivel,


### PR DESCRIPTION
This pull request includes a change to the `SELECT` statement in the `models/raw/unidades_administrativas/raw_unidades_administrativas_orgaos.sql` file. The most significant update is the removal of the `id_unidade_administrativa_pai` column from the schema.

Schema updates:

* [`models/raw/unidades_administrativas/raw_unidades_administrativas_orgaos.sql`](diffhunk://#diff-cb048962ff34489823adbfa9aee94b17cc6724dccdf64ed7171dd9281893e357L11-R14): Commented out the `id_unidade_administrativa_pai` column in the `SELECT` statement, indicating its removal from the schema. A note was added to clarify that the column has been removed.