### PR TITLE
feat: add partitioning by CPF, CNPJ, and CNO in raw_bcadastro models

### DIFF
--- a/models/raw/bcadastro/base/raw_base_bcadastro_chcno.sql
+++ b/models/raw/bcadastro/base/raw_base_bcadastro_chcno.sql
@@ -74,7 +74,9 @@ with
     ),
 
     dedup as (
-        select *
+        select *,
+        -- Partition by cno
+            cast(cno as int64) as cno_particao,
         from fonte_parseada
         qualify
             row_number() over (partition by cno order by airbyte.extracted_at desc) = 1

--- a/models/raw/bcadastro/base/raw_base_bcadastro_chcnpj.sql
+++ b/models/raw/bcadastro/base/raw_base_bcadastro_chcnpj.sql
@@ -150,7 +150,9 @@ with
     ),
 
     dedup as (
-        select *
+        select *,
+         -- Partition by cnpj
+            cast(cnpj as int64) as cnpj_particao,
         from fonte_parseada
         qualify
             row_number() over (partition by cnpj order by airbyte.extracted_at desc)

--- a/models/raw/bcadastro/base/raw_base_bcadastro_chcpf.sql
+++ b/models/raw/bcadastro/base/raw_base_bcadastro_chcpf.sql
@@ -82,7 +82,10 @@ with
     ),
 
     dedup as (
-        select *
+        select *,
+         -- Partition by cpfId
+            cast(cpfId as int64) as cpfId_particao,
+        
         from fonte_parseada
         qualify
             row_number() over (partition by cpfId order by airbyte.extracted_at desc)


### PR DESCRIPTION
This pull request introduces changes to enable partitioning in several SQL models within the `models/raw/bcadastro/base` directory. The updates primarily focus on adding partitioning logic to improve query performance and scalability by grouping data based on specific fields such as `cpf`, `cnpj`, `cno`, and others.

### Partitioning Updates:

* **`raw_base_bcadastro_chcaepf.sql`:** Added a `partition_by` configuration for the `cpf_particao` field, specifying its data type as `int64` and defining a range with a start, end, and interval. Additionally, updated the `dedup` step to include a new `cpf_particao` field derived from casting `nroCpf` to `int64`. [[1]](diffhunk://#diff-963a15313e2a6496594f94cf72b07c1838a43582668f051b6ae562deda039b52R7-R15) [[2]](diffhunk://#diff-963a15313e2a6496594f94cf72b07c1838a43582668f051b6ae562deda039b52R86-R95)

* **`raw_base_bcadastro_chcno.sql`:** Updated the `dedup` step to include a new `cno_particao` field by casting `cno` to `int64`, enabling partitioning by `cno`.

* **`raw_base_bcadastro_chcnpj.sql`:** Modified the `dedup` step to add a `cnpj_particao` field by casting `cnpj` to `int64`, allowing partitioning by `cnpj`.

* **`raw_base_bcadastro_chcpf.sql`:** Adjusted the `dedup` step to introduce a `cpfId_particao` field by casting `cpfId` to `int64`, facilitating partitioning by `cpfId`.