### PR TITLE
fix: update freshness configuration for compras_materiais_servicos_si…

### DIFF
--- a/models/raw/sigma/_sigma__sources.yml
+++ b/models/raw/sigma/_sigma__sources.yml
@@ -4,8 +4,8 @@ sources:
   - name: compras_materiais_servicos_sigma_staging
     database: rj-smfp
     schema: compras_materiais_servicos_sigma_staging
-    freshness: # default freshness
-      error_after: {count: 24, period: hour}
+    freshness: null # default freshness
+      #error_after: {count: 24, period: hour}
     loaded_at_field: _airbyte_extracted_at
     tables:
       - name: VW_CLASSE


### PR DESCRIPTION
This pull request includes a minor update to the `models/raw/sigma/_sigma__sources.yml` file. The change modifies the `freshness` property for the `compras_materiais_servicos_sigma_staging` source to set it to `null` and comments out the `error_after` configuration. 

* [`models/raw/sigma/_sigma__sources.yml`](diffhunk://#diff-4ef9f8f954fb467bb9f25a679e7a4df3fbebacd0c49101e8ec224d6ad858c261L7-R8): Changed `freshness` to `null` and commented out the `error_after` setting for the `compras_materiais_servicos_sigma_staging` source.