### PR TITLE
fix: ix issues in packages.yml

### DIFF
--- a/models/mart/gerenciamento/custos/mart_gerenciamento_custo_bigquery_jobs.yml
+++ b/models/mart/gerenciamento/custos/mart_gerenciamento_custo_bigquery_jobs.yml
@@ -10,8 +10,8 @@ models:
       - dbt_expectations.expect_column_values_to_be_between:
           name: mart_gerenciamento_custo_bigquery_jobs__datahora_criacao__valid_period
           column_name: datahora_criacao
-          min_value: "2024-01-01"
-          max_value: "{{ modules.datetime.datetime.now().strftime('%Y-%m-%d') }}"
+          min_value: "TIMESTAMP('2024-01-01')"
+          max_value: "CURRENT_TIMESTAMP()"
           severity: error
     columns:
       - name: id_job
@@ -67,12 +67,13 @@ models:
               severity: error
 
       - name: data_faturamento
-        description: "Data de faturamento do job (formato: 'YYYY-MM-DD'). Utilizada para partição e análise temporal dos custos."
+        description: "Data de faturamento do job (formato: 'YYYY-MM-DD'). Utilizada para partição e análise temporal dos custos. Pode ser NULL para jobs que não finalizaram ou falharam."
         data_type: date
         data_tests:
           - not_null:
               name: mart_gerenciamento_custo_bigquery_jobs__data_faturamento__not_null
-              severity: error
+              severity: warn
+              warn_if: ">0"
 
       - name: estado_job
         description: "Estado final do job no BigQuery (ex: DONE, FAILED, etc)."

--- a/models/mart/gerenciamento/custos/mart_gerenciamento_custo_gcp.sql
+++ b/models/mart/gerenciamento/custos/mart_gerenciamento_custo_gcp.sql
@@ -58,7 +58,7 @@ with base_data as (
     from {{ ref('raw_gcp_billing') }}
     {% if is_incremental() %}
         where usage_end_time > (
-            select coalesce(max(usage_end_time), timestamp('2025-01-01'))
+            select coalesce(max(usage_end_time), timestamp('1970-01-01'))
             from {{ this }}
         )
     {% endif %}

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,0 +1,6 @@
+packages:
+  - package: metaplane/dbt_expectations
+    version: 0.10.9
+  - package: godatadriven/dbt_date
+    version: 0.14.2
+sha1_hash: 21a7dec04068c9f3be92e2ccd765a95b9b0fe00e

--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: metaplane/dbt_expectations
+    version: 0.10.9


### PR DESCRIPTION
- Corrigir teste de data em mart_gerenciamento_custo_bigquery_jobs (TIMESTAMP vs STRING)
- Corrigir bug incremental em mart_gerenciamento_custo_gcp (data futura como fallback)
- Adicionar package-lock.yml com dependências fixadas
- Mudar severidade teste data_faturamento para warn (valores NULL são esperados)