### PR TITLE
Add new models for CNPJ and CPF from BCadastro API

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -50,6 +50,11 @@ models:
           +materialized: table
           +schema: turismo_fluxo_visitantes
           +tags: "daily"
+      iplanrio:
+        +project: rj-iplanrio
+        api_bcadastro:
+          +schema: api_bcadastro
+          +tags: ["daily", "bcadastro"]
     raw:
       +tags: "raw"
       bcadastro:

--- a/models/mart/iplanrio/api_bcadastro/mart_api_bcadastro__cnpj.sql
+++ b/models/mart/iplanrio/api_bcadastro/mart_api_bcadastro__cnpj.sql
@@ -1,0 +1,107 @@
+{{
+    config(
+        alias='cnpj' 
+    )
+}}
+
+select
+    cnpj.cnpj,
+    cnpj.razao_social,
+    cnpj.nome_fantasia,
+    cnpj.capital_social,
+    cnpj.cnae_fiscal,
+    cnpj.cnae_secundarias,
+    cnpj.nire,
+    struct(
+        cnpj.natureza_juridica.id,
+        cnpj.natureza_juridica.descricao
+    ) as natureza_juridica,
+    struct(
+        cnpj.porte.id,
+        cnpj.porte.descricao
+    ) as porte,
+    struct(
+        cnpj.matriz_filial.id,
+        cnpj.matriz_filial.descricao
+    ) as matriz_filial,
+    struct(
+        cnpj.orgao_registro.id,
+        cnpj.orgao_registro.descricao
+    ) as orgao_registro,
+    cnpj.inicio_atividade_data,
+    struct(
+        cnpj.situacao_cadastral.id,
+        cnpj.situacao_cadastral.descricao,
+        cnpj.situacao_cadastral.data,
+        cnpj.situacao_cadastral.motivo_id,
+        cnpj.situacao_cadastral.motivo_descricao
+    ) as situacao_cadastral,
+    struct(
+        cnpj.situacao_especial.descricao,
+        cnpj.situacao_especial.data
+    ) as situacao_especial,
+    struct(
+        cnpj.ente_federativo.id,
+        cnpj.ente_federativo.tipo
+    ) as ente_federativo,
+    struct(
+        cnpj.contato.telefone as telefone,
+        cnpj.contato.email
+    ) as contato,
+    struct(
+        cnpj.endereco.cep,
+        cnpj.endereco.id_pais,
+        cnpj.endereco.uf,
+        cnpj.endereco.id_municipio,
+        cnpj.endereco.municipio_nome,
+        cnpj.endereco.municipio_exterior_nome,
+        cnpj.endereco.bairro,
+        cnpj.endereco.tipo_logradouro,
+        cnpj.endereco.logradouro,
+        cnpj.endereco.numero,
+        cnpj.endereco.complemento
+    ) as endereco,
+    struct(
+        struct(
+            cnpj.contador.pf.tipo_crc,
+            cnpj.contador.pf.classificacao_crc,
+            cnpj.contador.pf.sequencial_crc,
+            cnpj.contador.pf.id
+        ) as pf,
+        struct(
+            cnpj.contador.pj.tipo_crc,
+            cnpj.contador.pj.classificacao_crc,
+            cnpj.contador.pj.sequencial_crc,
+            cnpj.contador.pj.id
+        ) as pj
+    ) as contador,
+    struct(
+        cnpj.responsavel.cpf,
+        cnpj.responsavel.qualificacao_id,
+        cnpj.responsavel.qualificacao_descricao,
+        cnpj.responsavel.inclusao_data
+    ) as responsavel,
+    cnpj.tipos_unidade,
+    cnpj.formas_atuacao,
+    cnpj.socios_quantidade,
+    cnpj.socios,
+    cnpj.sucessoes,
+    cnpj.timestamp,
+    cnpj.language,
+    struct(
+        cnpj.couchdb.id,
+        cnpj.couchdb.key,
+        cnpj.couchdb.rev,
+        cnpj.couchdb.seq,
+        cnpj.couchdb.last_seq
+    ) as couchdb,
+    struct(
+        cnpj.airbyte.raw_id,
+        cnpj.airbyte.extracted_at,
+        cnpj.airbyte.generation_id,
+        cnpj.airbyte.changes,
+        cnpj.airbyte.sync_id
+    ) as airbyte,
+    cnpj.cnpj_particao
+
+from {{ ref("raw_bcadastro_cnpj") }} as cnpj

--- a/models/mart/iplanrio/api_bcadastro/mart_api_bcadastro__cnpj.yml
+++ b/models/mart/iplanrio/api_bcadastro/mart_api_bcadastro__cnpj.yml
@@ -1,0 +1,419 @@
+version: 2
+
+models:
+  - name: mart_api_bcadastro__cnpj
+    description: "Modelo mart para dados de CNPJ da API do BCadastro, contendo informações empresariais, contato, endereço, sócios e metadados"
+    config:
+      alias: cnpj
+      contract:
+        enforced: true
+    columns:
+      # Chave primária
+      - name: cnpj
+        description: "Número do CNPJ da empresa"
+        data_type: string
+        quote: true
+
+      # Atributos principais da entidade
+      - name: razao_social
+        description: "Razão social da empresa"
+        data_type: string
+        quote: true
+
+      - name: nome_fantasia
+        description: "Nome fantasia da empresa"
+        data_type: string
+        quote: true
+
+      - name: capital_social
+        description: "Capital social da empresa"
+        data_type: integer
+
+      - name: cnae_fiscal
+        description: "Código CNAE fiscal principal"
+        data_type: string
+        quote: true
+
+      - name: cnae_secundarias
+        description: "Códigos CNAE secundários da empresa"
+        data_type: array<string>
+        quote: true
+
+      - name: nire
+        description: "Número de Identificação do Registro de Empresas"
+        data_type: string
+        quote: true
+
+      # Estrutura de natureza jurídica
+      - name: natureza_juridica.id
+        description: "ID da natureza jurídica"
+        data_type: string
+        quote: true
+
+      - name: natureza_juridica.descricao
+        description: "Descrição da natureza jurídica"
+        data_type: string
+        quote: true
+
+      # Estrutura de porte
+      - name: porte.id
+        description: "ID do porte da empresa"
+        data_type: string
+        quote: true
+
+      - name: porte.descricao
+        description: "Descrição do porte da empresa"
+        data_type: string
+        quote: true
+
+      # Estrutura de matriz/filial
+      - name: matriz_filial.id
+        description: "ID do indicador matriz/filial"
+        data_type: string
+        quote: true
+
+      - name: matriz_filial.descricao
+        description: "Descrição do indicador matriz/filial"
+        data_type: string
+        quote: true
+
+      # Estrutura de órgão de registro
+      - name: orgao_registro.id
+        description: "ID do órgão de registro"
+        data_type: string
+        quote: true
+
+      - name: orgao_registro.descricao
+        description: "Descrição do órgão de registro"
+        data_type: string
+        quote: true
+
+      # Data de início de atividade
+      - name: inicio_atividade_data
+        description: "Data de início das atividades da empresa"
+        data_type: date
+
+      # Estrutura de situação cadastral
+      - name: situacao_cadastral.id
+        description: "ID da situação cadastral"
+        data_type: string
+        quote: true
+
+      - name: situacao_cadastral.descricao
+        description: "Descrição da situação cadastral"
+        data_type: string
+        quote: true
+
+      - name: situacao_cadastral.data
+        description: "Data da situação cadastral"
+        data_type: date
+
+      - name: situacao_cadastral.motivo_id
+        description: "ID do motivo da situação cadastral"
+        data_type: string
+        quote: true
+
+      - name: situacao_cadastral.motivo_descricao
+        description: "Descrição do motivo da situação cadastral"
+        data_type: string
+        quote: true
+
+      # Estrutura de situação especial
+      - name: situacao_especial.descricao
+        description: "Descrição da situação especial"
+        data_type: string
+        quote: true
+
+      - name: situacao_especial.data
+        description: "Data da situação especial"
+        data_type: date
+
+      # Estrutura de ente federativo
+      - name: ente_federativo.id
+        description: "ID do ente federativo"
+        data_type: string
+        quote: true
+
+      - name: ente_federativo.tipo
+        description: "Tipo do ente federativo"
+        data_type: string
+        quote: true
+
+      # Estrutura de contato
+      - name: contato.telefone.ddd
+        description: "DDD do telefone"
+        data_type: string
+        quote: true
+      
+      - name: contato.telefone.telefone
+        description: "Número do telefone"
+        data_type: string
+        quote: true
+
+      - name: contato.email
+        description: "Endereço de email da empresa"
+        data_type: string
+        quote: true
+
+      # Estrutura de endereço
+      - name: endereco.cep
+        description: "CEP do endereço"
+        data_type: string
+        quote: true
+
+      - name: endereco.id_pais
+        description: "ID do país do endereço"
+        data_type: string
+        quote: true
+
+      - name: endereco.uf
+        description: "Unidade Federativa do endereço"
+        data_type: string
+        quote: true
+
+      - name: endereco.id_municipio
+        description: "ID do município do endereço"
+        data_type: string
+        quote: true
+
+      - name: endereco.municipio_nome
+        description: "Nome do município do endereço"
+        data_type: string
+        quote: true
+
+      - name: endereco.municipio_exterior_nome
+        description: "Nome do município exterior do endereço"
+        data_type: string
+        quote: true
+
+      - name: endereco.bairro
+        description: "Bairro do endereço"
+        data_type: string
+        quote: true
+
+      - name: endereco.tipo_logradouro
+        description: "Tipo do logradouro"
+        data_type: string
+        quote: true
+
+      - name: endereco.logradouro
+        description: "Nome do logradouro"
+        data_type: string
+        quote: true
+
+      - name: endereco.numero
+        description: "Número do endereço"
+        data_type: string
+        quote: true
+
+      - name: endereco.complemento
+        description: "Complemento do endereço"
+        data_type: string
+        quote: true
+
+      # Estrutura de contador
+      - name: contador.pf.tipo_crc
+        description: "Tipo do CRC do contador PF"
+        data_type: string
+        quote: true
+
+      - name: contador.pf.classificacao_crc
+        description: "Classificação do CRC do contador PF"
+        data_type: string
+        quote: true
+
+      - name: contador.pf.sequencial_crc
+        description: "Sequencial do CRC do contador PF"
+        data_type: string
+        quote: true
+
+      - name: contador.pf.id
+        description: "ID do contador PF"
+        data_type: string
+        quote: true
+
+      - name: contador.pj.tipo_crc
+        description: "Tipo do CRC do contador PJ"
+        data_type: string
+        quote: true
+
+      - name: contador.pj.classificacao_crc
+        description: "Classificação do CRC do contador PJ"
+        data_type: string
+        quote: true
+
+      - name: contador.pj.sequencial_crc
+        description: "Sequencial do CRC do contador PJ"
+        data_type: string
+        quote: true
+
+      - name: contador.pj.id
+        description: "ID do contador PJ"
+        data_type: string
+        quote: true
+
+      # Estrutura de responsável
+      - name: responsavel.cpf
+        description: "CPF do responsável"
+        data_type: string
+        quote: true
+
+      - name: responsavel.qualificacao_id
+        description: "ID da qualificação do responsável"
+        data_type: string
+        quote: true
+
+      - name: responsavel.qualificacao_descricao
+        description: "Descrição da qualificação do responsável"
+        data_type: string
+        quote: true
+
+      - name: responsavel.inclusao_data
+        description: "Data de inclusão do responsável"
+        data_type: date
+
+      # Arrays de negócio
+      - name: tipos_unidade
+        description: "Tipos de unidade da empresa"
+        data_type: array<string>
+        quote: true
+
+      - name: formas_atuacao
+        description: "Formas de atuação da empresa"
+        data_type: array<string>
+        quote: true
+
+      - name: socios_quantidade
+        description: "Quantidade de sócios da empresa"
+        data_type: integer
+
+      - name: socios.codigo_pais
+        description: "Código do país do sócio"
+        data_type: string
+        quote: true
+
+      - name: socios.cpf_socio
+        description: "CPF do sócio"
+        data_type: string
+        quote: true
+
+      - name: socios.cnpj_socio
+        description: "CNPJ do sócio"
+        data_type: string
+        quote: true
+
+      - name: socios.cpf_representante_legal
+        description: "CPF do representante legal do sócio"
+        data_type: string
+        quote: true
+      
+      - name: socios.data_situacao_especial
+        description: "Data de entrada do sócio na empresa"
+        data_type: date
+        quote: true
+
+      - name: socios.nome_socio_estrangeiro
+        description: "Nome do sócio estrangeiro"
+        data_type: string
+        quote: true
+
+      - name: socios.qualificacao_representante_legal
+        description: "Qualificação do representante legal do sócio"
+        data_type: string
+        quote: true
+
+      - name: socios.qualificacao_socio
+        description: "Qualificação do sócio"
+        data_type: string
+        quote: true
+      
+      - name: socios.tipo
+        description: "Tipo do sócio"
+        data_type: string
+        quote: true
+
+      - name: sucessoes.evento_sucedida
+        description: "Evento de sucessão empresarial"
+        data_type: string
+        quote: true
+
+      - name: sucessoes.data_evento_sucedida
+        description: "Data do evento de sucessão empresarial"
+        data_type: date
+        quote: true
+
+      - name: sucessoes.data_processamento
+        description: "Data de processamento da sucessão"
+        data_type: date
+        quote: true
+
+      - name: sucessoes.sucessoras
+        description: "Empresas sucessoras"
+        data_type: string
+        quote: true
+
+      # Metadados
+      - name: timestamp
+        description: "Timestamp dos dados"
+        data_type: string
+
+      - name: language
+        description: "Idioma dos dados"
+        data_type: string
+        quote: true
+
+      # Estrutura do CouchDB
+      - name: couchdb.id
+        description: "ID do CouchDB"
+        data_type: string
+        quote: true
+
+      - name: couchdb.key
+        description: "Chave do CouchDB"
+        data_type: string
+        quote: true
+
+      - name: couchdb.rev
+        description: "Revisão do CouchDB"
+        data_type: string
+        quote: true
+
+      - name: couchdb.seq
+        description: "Sequência do CouchDB"
+        data_type: string
+        quote: true
+
+      - name: couchdb.last_seq
+        description: "Última sequência do CouchDB"
+        data_type: string
+        quote: true
+
+      # Estrutura do Airbyte
+      - name: airbyte.raw_id
+        description: "ID raw do Airbyte"
+        data_type: string
+        quote: true
+
+      - name: airbyte.extracted_at
+        description: "Data de extração do Airbyte"
+        data_type: timestamp
+
+      - name: airbyte.generation_id
+        description: "ID de geração do Airbyte"
+        data_type: integer
+
+      - name: airbyte.changes
+        description: "Mudanças registradas pelo Airbyte"
+        data_type: string
+        quote: true
+
+      - name: airbyte.sync_id
+        description: "ID de sincronização do Airbyte"
+        data_type: string
+        quote: true
+
+      # Coluna de particionamento
+      - name: cnpj_particao
+        description: "Coluna de particionamento baseada no CNPJ"
+        data_type: integer
+        quote: true

--- a/models/mart/iplanrio/api_bcadastro/mart_api_bcadastro__cpf.sql
+++ b/models/mart/iplanrio/api_bcadastro/mart_api_bcadastro__cpf.sql
@@ -1,0 +1,69 @@
+{{
+    config(
+        alias='cpf'    )
+}}
+
+select
+    cpf.cpf,
+    cpf.nome,
+    cpf.nome_social,
+    cpf.mae_nome,
+    cpf.nascimento_data,
+    cpf.inscricao_data,
+    cpf.atualizacao_data,
+    cpf.situacao_cadastral_tipo,
+    cpf.sexo,
+    cpf.obito_ano,
+    cpf.estrangeiro_indicador,
+    cpf.residente_exterior_indicador,
+    struct(
+        struct(
+            cpf.contato.telefone.ddi,
+            cpf.contato.telefone.ddd,
+            cpf.contato.telefone.numero
+        ) as telefone,
+        cpf.contato.email
+    ) as contato,
+    struct(
+        cpf.endereco.cep,
+        cpf.endereco.uf,
+        cpf.endereco.municipio,
+        cpf.endereco.bairro,
+        cpf.endereco.tipo_logradouro,
+        cpf.endereco.logradouro,
+        cpf.endereco.numero,
+        cpf.endereco.complemento
+    ) as endereco,
+    struct(
+        cpf.nascimento_local.id_pais,
+        cpf.nascimento_local.pais,
+        cpf.nascimento_local.uf,
+        cpf.nascimento_local.id_municipio,
+        cpf.nascimento_local.municipio
+    ) as nascimento_local,
+    struct(
+        cpf.ocupacao.id,
+        cpf.ocupacao.nome,
+        cpf.ocupacao.id_natureza,
+        cpf.ocupacao.id_ua
+    ) as ocupacao,
+    struct(
+        cpf.metadados.ano_exercicio,
+        cpf.metadados.version,
+        cpf.metadados.tipo,
+        cpf.metadados.timestamp
+    ) as metadados,
+    struct(
+        cpf.airbyte.seq,
+        cpf.airbyte.last_seq,
+        cpf.airbyte.airbyte_raw_id,
+        cpf.airbyte.airbyte_extracted_at,
+        struct(
+            cpf.airbyte.airbyte_meta.changes,
+            cpf.airbyte.airbyte_meta.sync_id
+        ) as airbyte_meta,
+        cpf.airbyte.airbyte_generation_id
+    ) as airbyte,
+    cpf.cpf_particao
+
+from {{ ref("raw_bcadastro_cpf") }}

--- a/models/mart/iplanrio/api_bcadastro/mart_api_bcadastro__cpf.yml
+++ b/models/mart/iplanrio/api_bcadastro/mart_api_bcadastro__cpf.yml
@@ -1,0 +1,272 @@
+version: 2
+
+models:
+  - name: mart_api_bcadastro__cpf
+    description: "Modelo mart para dados de CPF da API do BCadastro, contendo informações pessoais, contato, endereço e metadados"
+    config:
+      alias: cpf
+      contract:
+        enforced: true
+    columns:
+      # Chave primária
+      - name: cpf
+        description: "Número do CPF do cidadão"
+        data_type: string
+        quote: true
+
+      # Atributos principais da entidade
+      - name: nome
+        description: "Nome completo do cidadão"
+        data_type: string
+        quote: true
+
+      - name: nome_social
+        description: "Nome social do cidadão"
+        data_type: string
+        quote: true
+
+      - name: mae_nome
+        description: "Nome da mãe do cidadão"
+        data_type: string
+        quote: true
+
+      - name: nascimento_data
+        description: "Data de nascimento do cidadão"
+        data_type: date
+
+      - name: inscricao_data
+        description: "Data de inscrição no CPF"
+        data_type: date
+
+      - name: atualizacao_data
+        description: "Data da última atualização do cadastro"
+        data_type: date
+
+      - name: situacao_cadastral_tipo
+        description: "Tipo de situação cadastral do CPF"
+        data_type: string
+        quote: true
+
+      - name: sexo
+        description: "Sexo do cidadão"
+        data_type: string
+        quote: true
+
+      - name: obito_ano
+        description: "Ano do óbito do cidadão"
+        data_type: string
+
+      - name: estrangeiro_indicador
+        description: "Indicador se o cidadão é estrangeiro"
+        data_type: boolean
+
+      - name: residente_exterior_indicador
+        description: "Indicador se o cidadão reside no exterior"
+        data_type: boolean
+
+      # Estrutura de contato
+      - name: contato
+        description: "Informações de contato do cidadão"
+        data_type: struct
+        quote: true
+
+      - name: contato.telefone
+        description: "Informações do telefone do cidadão"
+        data_type: struct
+        quote: true
+
+      - name: contato.telefone.ddi
+        description: "Código DDI do telefone"
+        data_type: string
+        quote: true
+
+      - name: contato.telefone.ddd
+        description: "Código DDD do telefone"
+        data_type: string
+        quote: true
+
+      - name: contato.telefone.numero
+        description: "Número do telefone"
+        data_type: string
+        quote: true
+
+      - name: contato.email
+        description: "Endereço de email do cidadão"
+        data_type: string
+        quote: true
+
+      # Estrutura de endereço
+      - name: endereco
+        description: "Informações de endereço do cidadão"
+        data_type: struct
+        quote: true
+
+      - name: endereco.cep
+        description: "CEP do endereço"
+        data_type: string
+        quote: true
+
+      - name: endereco.uf
+        description: "Unidade Federativa do endereço"
+        data_type: string
+        quote: true
+
+      - name: endereco.municipio
+        description: "Município do endereço"
+        data_type: string
+        quote: true
+
+      - name: endereco.bairro
+        description: "Bairro do endereço"
+        data_type: string
+        quote: true
+
+      - name: endereco.tipo_logradouro
+        description: "Tipo do logradouro"
+        data_type: string
+        quote: true
+
+      - name: endereco.logradouro
+        description: "Nome do logradouro"
+        data_type: string
+        quote: true
+
+      - name: endereco.numero
+        description: "Número do endereço"
+        data_type: string
+        quote: true
+
+      - name: endereco.complemento
+        description: "Complemento do endereço"
+        data_type: string
+        quote: true
+
+      # Estrutura de local de nascimento
+      - name: nascimento_local
+        description: "Informações do local de nascimento"
+        data_type: struct
+        quote: true
+
+      - name: nascimento_local.id_pais
+        description: "ID do país de nascimento"
+        data_type: string
+        quote: true
+
+      - name: nascimento_local.pais
+        description: "Nome do país de nascimento"
+        data_type: string
+        quote: true
+
+      - name: nascimento_local.uf
+        description: "UF de nascimento"
+        data_type: string
+        quote: true
+
+      - name: nascimento_local.id_municipio
+        description: "ID do município de nascimento"
+        data_type: string
+        quote: true
+
+      - name: nascimento_local.municipio
+        description: "Nome do município de nascimento"
+        data_type: string
+        quote: true
+
+      # Estrutura de ocupação
+      - name: ocupacao
+        description: "Informações de ocupação do cidadão"
+        data_type: struct
+        quote: true
+
+      - name: ocupacao.id
+        description: "ID da ocupação"
+        data_type: string
+        quote: true
+
+      - name: ocupacao.nome
+        description: "Nome da ocupação"
+        data_type: string
+        quote: true
+
+      - name: ocupacao.id_natureza
+        description: "ID da natureza da ocupação"
+        data_type: string
+        quote: true
+
+      - name: ocupacao.id_ua
+        description: "ID da unidade administrativa da ocupação"
+        data_type: string
+        quote: true
+
+      # Estrutura de metadados
+      - name: metadados
+        description: "Metadados do registro"
+        data_type: struct
+        quote: true
+
+      - name: metadados.ano_exercicio
+        description: "Ano de exercício dos dados"
+        data_type: integer
+
+      - name: metadados.version
+        description: "Versão dos dados"
+        data_type: string
+        quote: true
+
+      - name: metadados.tipo
+        description: "Tipo do registro"
+        data_type: string
+        quote: true
+
+      - name: metadados.timestamp
+        description: "Timestamp dos metadados"
+        data_type: string
+
+      # Estrutura do Airbyte
+      - name: airbyte
+        description: "Metadados de sincronização do Airbyte"
+        data_type: struct
+        quote: true
+
+      - name: airbyte.seq
+        description: "Sequência do Airbyte"
+        data_type: string
+
+      - name: airbyte.last_seq
+        description: "Última sequência do Airbyte"
+        data_type: string
+
+      - name: airbyte.airbyte_raw_id
+        description: "ID raw do Airbyte"
+        data_type: string
+        quote: true
+
+      - name: airbyte.airbyte_extracted_at
+        description: "Data de extração do Airbyte"
+        data_type: timestamp
+
+      - name: airbyte.airbyte_meta
+        description: "Metadados do Airbyte"
+        data_type: struct
+        quote: true
+
+      - name: airbyte.airbyte_meta.changes
+        description: "Mudanças registradas pelo Airbyte"
+        data_type: string
+        quote: true
+
+      - name: airbyte.airbyte_meta.sync_id
+        description: "ID de sincronização do Airbyte"
+        data_type: string
+        quote: true
+
+      - name: airbyte.airbyte_generation_id
+        description: "ID de geração do Airbyte"
+        data_type: integer
+        quote: true
+
+      # Coluna de particionamento
+      - name: cpf_particao
+        description: "Coluna de particionamento baseada no CPF"
+        data_type: integer
+        quote: true


### PR DESCRIPTION
This commit introduces two new models: `mart_api_bcadastro__cnpj` and `mart_api_bcadastro__cpf`, along with their corresponding YAML configuration files. The CNPJ model captures various business-related information, while the CPF model includes personal details. Both models are configured for daily updates and are structured to facilitate data extraction from the raw BCadastro sources.