### PR TITLE
fix(sme): fix query avaliacao_bimestral_2021_a_2026

### DIFF
--- a/models/raw/sme/educacao_basica_avaliacao/avaliacao_bimestral_2021_a_2026.sql
+++ b/models/raw/sme/educacao_basica_avaliacao/avaliacao_bimestral_2021_a_2026.sql
@@ -176,11 +176,15 @@ SELECT
     WHEN cd_disciplina IS NOT NULL THEN SAFE_CAST(cd_disciplina AS INT64)
     WHEN nm_disciplina = "Língua Portuguesa" THEN 1
     WHEN nm_disciplina = "Matemática" THEN 2
+    WHEN nm_disciplina = "Ciências da Natureza" THEN 29
+    WHEN nm_disciplina = "Ciências Humanas" THEN 30
     ELSE NULL
     END as codigo_disciplina,
   CASE
     WHEN nm_disciplina = "Língua Portuguesa" OR SAFE_CAST(cd_disciplina AS INT64) = 1 THEN "LP"
     WHEN nm_disciplina = "Matemática" OR SAFE_CAST(cd_disciplina AS INT64) = 2 THEN "MT"
+    WHEN nm_disciplina = "Ciências da Natureza" OR SAFE_CAST(cd_disciplina AS INT64) = 29 THEN "CN"
+    WHEN nm_disciplina = "Ciências Humanas" OR SAFE_CAST(cd_disciplina AS INT64) = 30 THEN "CH"
     ELSE NULL
     END as sigla_disciplina,
   SAFE_CAST(SAFE_CAST(SAFE_CAST(fl_previsto as FLOAT64) AS INT64) AS BOOL) as indicador_previsto_avaliacao,
@@ -215,11 +219,15 @@ SELECT
     WHEN cd_disciplina IS NOT NULL THEN SAFE_CAST(cd_disciplina AS INT64)
     WHEN nm_disciplina = "Língua Portuguesa" THEN 1
     WHEN nm_disciplina = "Matemática" THEN 2
+    WHEN nm_disciplina = "Ciências da Natureza" THEN 29
+    WHEN nm_disciplina = "Ciências Humanas" THEN 30
     ELSE NULL
     END as codigo_disciplina,
   CASE
     WHEN nm_disciplina = "Língua Portuguesa" OR SAFE_CAST(cd_disciplina AS INT64) = 1 THEN "LP"
     WHEN nm_disciplina = "Matemática" OR SAFE_CAST(cd_disciplina AS INT64) = 2 THEN "MT"
+    WHEN nm_disciplina = "Ciências da Natureza" OR SAFE_CAST(cd_disciplina AS INT64) = 29 THEN "CN"
+    WHEN nm_disciplina = "Ciências Humanas" OR SAFE_CAST(cd_disciplina AS INT64) = 30 THEN "CH"
     ELSE NULL
     END as sigla_disciplina,
   SAFE_CAST(SAFE_CAST(SAFE_CAST(fl_previsto as FLOAT64) AS INT64) AS BOOL) as indicador_previsto_avaliacao,


### PR DESCRIPTION
Consertando a query de avaliacao_bimestral_2021_a_2026. 
Foram acrescentadas as matérias `Ciências da Natureza` e `Ciências Humanas`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novas Funcionalidades**
  * Expansão do catálogo de disciplinas nas avaliações bimestrais com a adição de Ciências da Natureza e Ciências Humanas, complementando o sistema existente que já oferecia Língua Portuguesa e Matemática.
  * Processamento e análise de dados de avaliações dos períodos de 2025 e 2026 agora está completamente integrado ao sistema de educação básica.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->