### PR TITLE
fix(sql): sicop processo2

### DIFF
--- a/models/raw/iplanrio/sicop/raw_sicop_processo2.sql
+++ b/models/raw/iplanrio/sicop/raw_sicop_processo2.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        alias="raw_sicop_processo2",
+        alias="processo2",
         description="Dados brutos de processo2 do SICOP (VW_PROCESSO2_DLK)"
     )
 }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - O nome público de um objeto/modelo foi simplificado para `processo2`, deixando a identificação exibida mais curta e consistente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->