### PR TITLE
feat(cnpj): implement hash partitioning for alphanumeric CNPJ values

### DIFF
--- a/macros/string/hash_particao.sql
+++ b/macros/string/hash_particao.sql
@@ -1,0 +1,3 @@
+{% macro hash_particao(column) %}
+    mod(abs(farm_fingerprint({{ column }})), 100000000000000)
+{% endmacro %}

--- a/models/mart/iplanrio/api_bcadastro/mart_api_bcadastro__cnpj.yml
+++ b/models/mart/iplanrio/api_bcadastro/mart_api_bcadastro__cnpj.yml
@@ -361,6 +361,9 @@ models:
 
       # Coluna de particionamento
       - name: cnpj_particao
-        description: "Coluna de particionamento baseada no CNPJ"
+        description: >
+          Partição do CNPJ: MOD(ABS(FARM_FINGERPRINT(cnpj)), 100000000000000), sempre int64
+          mesmo com CNPJs alfanuméricos. Para filtrar por essa coluna, aplique a mesma
+          expressão no valor de busca.
         data_type: integer
         quote: true

--- a/models/raw/iplanrio/bcadastro/base/raw_base_bcadastro_chcnpj.sql
+++ b/models/raw/iplanrio/bcadastro/base/raw_base_bcadastro_chcnpj.sql
@@ -145,8 +145,10 @@ with
 
     dedup as (
         select *,
-        -- Partition by cnpj
-            cast(cnpj as int64) as cnpj_particao,
+        -- CNPJ vai passar a aceitar caracteres alfanuméricos (Receita Federal), por isso
+        -- a particao usa hash em vez de CAST direto do numero do CNPJ, garantindo que o
+        -- resultado seja sempre int64 e caiba no range 0-99999999999999 do partition_by.
+            {{ hash_particao("cnpj") }} as cnpj_particao,
         from fonte_parseada
         qualify
             row_number() over (partition by cnpj order by airbyte.extracted_at desc)

--- a/models/raw/iplanrio/bcadastro/intermediate/int_bcadastro_chcnpj_parse.sql
+++ b/models/raw/iplanrio/bcadastro/intermediate/int_bcadastro_chcnpj_parse.sql
@@ -308,7 +308,10 @@ with
             ) as airbyte,
     
 
-            cast(est.cnpj as int64) as cnpj_particao,
+            -- CNPJ vai passar a aceitar caracteres alfanuméricos (Receita Federal), por isso
+            -- a particao usa hash em vez de CAST direto do numero do CNPJ, garantindo que o
+            -- resultado seja sempre int64 e caiba no range 0-99999999999999 do partition_by.
+            {{ hash_particao("est.cnpj") }} as cnpj_particao,
 
         from dedup_estabelecimento as est
         left join dedup_matriz as mat on est.cnpj_matriz = mat.cnpj_matriz

--- a/models/raw/iplanrio/bcadastro/raw_bcadastro_cnpj.sql
+++ b/models/raw/iplanrio/bcadastro/raw_bcadastro_cnpj.sql
@@ -530,7 +530,10 @@ with
             im.descricao as indicador_matriz_descricao,
             qr.descricao as qualificacao_responsavel_descricao,
 
-            cast(t.id_cnpj as int64) as cnpj_particao
+            -- CNPJ vai passar a aceitar caracteres alfanuméricos (Receita Federal), por isso
+            -- a particao usa hash em vez de CAST direto do numero do CNPJ, garantindo que o
+            -- resultado seja sempre int64 e caiba no range 0-99999999999999 do partition_by.
+            {{ hash_particao("t.id_cnpj") }} as cnpj_particao
 
         from cnpj_renomeada t
         left join

--- a/models/raw/iplanrio/bcadastro/raw_bcadastro_cnpj.yml
+++ b/models/raw/iplanrio/bcadastro/raw_bcadastro_cnpj.yml
@@ -462,6 +462,9 @@ models:
         quote: true
 
       - name: cnpj_particao
-        description: Partição do CNPJ para otimização de processamento e consulta.
+        description: >
+          Partição do CNPJ: MOD(ABS(FARM_FINGERPRINT(cnpj)), 100000000000000), sempre int64
+          mesmo com CNPJs alfanuméricos. Para filtrar por essa coluna, aplique a mesma
+          expressão no valor de busca.
         data_type: integer
         quote: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novas funcionalidades**
  * Adicionado cálculo padronizado de particionamento para CNPJs usando hash.
  * CNPJs alfanuméricos agora geram valores `int64` dentro do intervalo esperado para particionamento.
  * Aplicado o novo cálculo nos modelos de cadastro correspondentes.

* **Documentação**
  * Atualizadas as descrições do campo `cnpj_particao`, incluindo a expressão utilizada e orientação para filtros e consultas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->