### PR TITLE
add(dbt): activate model dialogflowcx

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -51,6 +51,11 @@ models:
           +schema: educacao_basica_frequencia
           +tags: ["daily", "sme"]
           +project: rj-sme
+      dialogflowcx:
+        +project: rj-chatbot-dev
+        +schema: dialogflowcx
+        +tags: ["daily"]
+        +materialized: table
       sma:
         +project: rj-sma
         ergon_saude:

--- a/models/mart/dialogflowcx/mart__conversas_completas_metricas.sql
+++ b/models/mart/dialogflowcx/mart__conversas_completas_metricas.sql
@@ -1,0 +1,17 @@
+{{
+    config(
+        alias='conversas_completas_metricas'
+    )
+}}
+
+SELECT
+  MIN(request_time) as request_time,
+  conversa_completa_id,
+  MAX(ambiente) AS ambiente,
+  ARRAY_AGG(DISTINCT conversation_name) AS conversation_name_list,
+  AVG(conversa_completa_turnos_em_menus) AS conversa_completa_turnos_em_menus,
+  MAX(conversa_completa_fluxos_interagidos) AS conversa_completa_fluxos_interagidos,
+  MAX(conversa_completa_duracao) AS conversa_completa_duracao,
+  MAX(conversa_completa_ultimo_fluxo_servico) AS conversa_completa_ultimo_fluxo_servico
+FROM {{ ref('mart__fim_conversas') }}
+GROUP BY conversa_completa_id

--- a/models/mart/dialogflowcx/mart__fim_conversas.sql
+++ b/models/mart/dialogflowcx/mart__fim_conversas.sql
@@ -1,0 +1,183 @@
+{{
+    config(
+        alias='fim_conversas'
+    )
+}}
+
+with ultima_interacao as (
+SELECT
+  conversation_name,
+  MAX(turn_position) as last_turn
+FROM `rj-chatbot-dev.dialogflowcx.historico_conversas`
+GROUP BY conversation_name
+),
+
+# Captura apenas mensagens vindas do ASC através da mensagem que inicia a conversa
+primeira_interacao AS (
+  SELECT
+    conversation_name,
+    `rj-chatbot-dev.dialogflowcx`.inicial_sentence_to_flow_name(JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.text'))) as fluxo_primeira_interacao,
+    request_time AS hora_primeira_interacao,
+    JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.text')) AS primeira_mensagem,
+    JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.ambiente')) AS ambiente
+  FROM `rj-chatbot-dev.dialogflowcx.historico_conversas`
+  WHERE
+    turn_position = 1
+    -- AND `rj-chatbot-dev.dialogflowcx.inicial_sentences`(JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.text')))
+    AND JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.match.matchType')) != "PLAYBOOK"
+),
+
+duplicate_conversations AS (
+  SELECT
+    conversation_name,
+    turn_position,
+    COUNT(*) AS contagem
+  FROM `rj-chatbot-dev.dialogflowcx.historico_conversas`
+  GROUP BY conversation_name, turn_position
+  HAVING COUNT(*) > 1
+),
+hist AS (
+  SELECT
+    h.*
+  FROM `rj-chatbot-dev.dialogflowcx.historico_conversas` AS h
+  LEFT JOIN `rj-chatbot-dev.dialogflowcx.fim_conversas_da` AS da
+    ON da.conversa_completa_id = h.conversation_name
+  LEFT JOIN `rj-chatbot-dev.dialogflowcx.fim_conversas_macrofluxos` AS mf
+    ON mf.conversa_completa_id = h.conversation_name
+  LEFT JOIN duplicate_conversations AS bc
+    ON h.conversation_name = bc.conversation_name
+       AND h.turn_position = bc.turn_position
+  WHERE da.conversation_name IS NULL
+    AND mf.conversation_name IS NULL
+    AND bc.conversation_name IS NULL
+),
+
+fim_conversas_1746 AS (
+SELECT
+  hist.conversation_name,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.usuario_cpf')) AS cpf,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.phone')) as telefone,
+  CASE
+    WHEN pi.ambiente = "production" THEN "Produção"
+    ELSE "Homologação"
+  END ambiente,
+  INITCAP(pi.fluxo_primeira_interacao) as fluxo_nome,
+  FORMAT_DATETIME("%d/%m/%Y às %H:%M", DATETIME(request_time, "America/Buenos_Aires")) as horario,
+  DATETIME(request_time, "America/Buenos_Aires") as request_time,
+  ROUND(DATE_DIFF(request_time, hora_primeira_interacao, SECOND)/60,1) as duracao_minutos,
+  hist.turn_position as ultimo_turno,
+  pi.primeira_mensagem,
+  response,
+  CASE
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentPage.displayName')) = "End Session" THEN true
+    ELSE false
+    END conversa_finalizada,
+  CASE
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.solicitacao_protocolo')) IS NOT NULL THEN "chamado_aberto"
+    WHEN hist.turn_position = 1 THEN "hard_bounce"
+    WHEN
+      hist.turn_position = 2
+      AND (
+        ENDS_WITH(JSON_VALUE(JSON_EXTRACT(derived_data, '$.agentUtterances')), 'VOLTAR')
+        OR ENDS_WITH(JSON_VALUE(JSON_EXTRACT(derived_data, '$.agentUtterances')), 'SAIR')
+      )
+      THEN  "timeout_usuario_pre_transacao" -- "soft_bounce"
+    WHEN
+      hist.turn_position = 2
+      THEN "timeout_usuario_pos_transacao"
+    WHEN
+      JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.solicitacao_retorno')) = "erro_interno_timeout"
+      THEN "timeout SGRC"
+    WHEN ENDS_WITH(JSON_VALUE(JSON_EXTRACT(derived_data, '$.agentUtterances')),'TRANSBORDO') THEN "transbordo"
+    WHEN
+      # Casos em que o Chatbot identificou a inelegibilidade
+      (JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_abertura_chamado_justificativa')) != "erro_desconhecido"
+      AND
+      (JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_abertura_chamado')) = "false"
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_endereco_abertura_chamado')) = "false")
+      )
+      # Casos em que o SGRC identificou a inelegibilidade
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_abertura_chamado_justificativa')) = "chamado_aberto"
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_abertura_chamado_justificativa')) = "chamado_fechado_12_dias"
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_endereco_abertura_chamado_justificativa')) = "chamado_aberto"
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_endereco_abertura_chamado_justificativa')) = "chamado_fechado_12_dias"
+      THEN "impedimento_regra_negocio"
+    WHEN
+      JSON_VALUE(JSON_EXTRACT(derived_data, '$.agentUtterances')) IS NULL
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.solicitacao_retorno')) = "erro_interno"
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_endereco_abertura_chamado_justificativa')) = "erro_desconhecido"
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_abertura_chamado_justificativa')) = "erro_desconhecido"
+      THEN "timeout interno"
+    WHEN
+        ENDS_WITH(JSON_VALUE(JSON_EXTRACT(derived_data, '$.agentUtterances')), 'VOLTAR')
+     OR ENDS_WITH(JSON_VALUE(JSON_EXTRACT(derived_data, '$.agentUtterances')), 'SAIR')
+     THEN "desistência"
+    ELSE  "timeout_usuario_pos_transacao"
+    END classificacao_conversa,
+  CASE
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.solicitacao_protocolo')) IS NOT NULL
+      OR ENDS_WITH(JSON_VALUE(JSON_EXTRACT(derived_data, '$.agentUtterances')), 'VOLTAR')
+      OR ENDS_WITH(JSON_VALUE(JSON_EXTRACT(derived_data, '$.agentUtterances')), 'SAIR')
+      THEN "sucesso"
+    ELSE "falha"
+    END status_final_conversa,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentPage.displayName')) as passo_falha,
+  CASE
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) = '1647 (RRL)' THEN 'Remoção de Resíduo'
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) = '1614 (PAL)' THEN 'Poda de Árvore'
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) = '1464 (VACIO)' THEN 'Verificação de Ar Condicionado Inoperante em Ônibus'
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) = '152 (RLU)' THEN 'Reparo de Luminária'
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) = '182 (RBDAP)' THEN 'Reparo de Buraco, Deformação ou Afundamento na pista'
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) = '3581 (FEIV)' THEN "Fiscalização de Estacionamento Irregular de Veículo"
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) = '3802 (RSTA)' THEN "Reparo de Sinal de Trânsito Apagado"
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) = '1607 (REBI)' THEN "Remoção de Entulho e Bens Inservíveis"
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) = '192 (DBGRR)' THEN "Desobstrução de bueiros, galerias, ramais de águas pluviais e ralos"
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) = '2569 (RTG)' THEN "Reposição de Tampão ou Grelha"
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) = '223 (RSTAP)' THEN "Reparo de Sinal de Trânsito em Amarelo Piscante"
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) = '1618 (CRCA)' THEN "Controle de Roedores e Caramujos Africanos"
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) = '3803 (RSTAAV)' THEN "Reparo de Sinal de Trânsito Abalroado ou Ausente ou Virado"
+    ELSE JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName'))
+    END as fluxo_falha,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.solicitacao_retorno')) erro_abertura_ticket,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.solicitacao_protocolo')) protocolo,
+  SAFE_CAST(NULL AS INT64) AS turnos_em_menus,
+  SAFE_CAST(NULL AS INT64) AS estimativa_turnos_menu,
+  SAFE_CAST(NULL AS INT64) AS turnos_em_servico,
+  SAFE_CAST(NULL AS INT64) AS estimativa_turnos_servico,
+  SAFE_CAST(NULL AS INT64) AS turnos_em_endereco,
+  SAFE_CAST(NULL AS INT64) AS turnos_em_identificacao,
+  hist.conversation_name as conversa_completa_id,
+  SAFE_CAST(NULL AS INT64) AS conversa_completa_turnos_em_menus,
+  SAFE_CAST(NULL AS INT64) AS conversa_completa_fluxos_interagidos,
+  SAFE_CAST(NULL AS INT64) AS conversa_completa_duracao,
+  SAFE_CAST(NULL AS STRING) AS conversa_completa_ultimo_fluxo_servico,
+FROM hist
+INNER JOIN ultima_interacao as ui
+  ON hist.conversation_name = ui.conversation_name AND hist.turn_position = ui.last_turn
+INNER JOIN primeira_interacao as pi
+  ON hist.conversation_name = pi.conversation_name)
+
+SELECT
+  *,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.codigo_servico_1746')) as codigo_servico,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.teste_ab_versao')) as teste_ab_versao,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.nota_pesquisa')) as nota_pesquisa_satisfacao
+FROM fim_conversas_1746
+
+UNION ALL
+
+SELECT
+  *,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.codigo_servico_1746')) as codigo_servico,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.teste_ab_versao')) as teste_ab_versao,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.nota_pesquisa')) as nota_pesquisa_satisfacao
+FROM {{ ref('mart__fim_conversas_da') }}
+
+UNION ALL
+
+SELECT
+  *,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.codigo_servico_1746')) as codigo_servico,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.teste_ab_versao')) as teste_ab_versao,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.nota_pesquisa')) as nota_pesquisa_satisfacao
+FROM {{ ref('mart__fim_conversas_macrofluxos') }}

--- a/models/mart/dialogflowcx/mart__fim_conversas_da.sql
+++ b/models/mart/dialogflowcx/mart__fim_conversas_da.sql
@@ -1,0 +1,289 @@
+{{
+    config(
+        alias='fim_conversas_da'
+    )
+}}
+
+WITH filtro_divida_ativa AS (
+    SELECT
+      conversation_name
+    FROM `rj-chatbot-dev.dialogflowcx.historico_conversas`
+    WHERE
+      JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.ambiente')) = "production"
+      AND turn_position = 1
+      AND JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.text')) = "dívida ativa"
+),
+historico AS (
+    SELECT
+      h.conversation_name,
+      JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.text')) as mensagem_cidadao,
+      JSON_VALUE(JSON_EXTRACT(derived_data, '$.agentUtterances')) as resposta_bot,
+      turn_position,
+      JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) as fluxo,
+      JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentPage.displayName')) as passo,
+      FORMAT_DATETIME("%d/%m/%Y às %H:%M", DATETIME(request_time, "America/Buenos_Aires")) as horario,
+      JSON_EXTRACT(response, '$.queryResult.parameters') as parametros,
+      request_time,
+      response
+    FROM `rj-chatbot-dev.dialogflowcx.historico_conversas` as h
+    INNER JOIN filtro_divida_ativa as f ON f.conversation_name = h.conversation_name
+    ORDER BY conversation_name, request_time ASC
+),
+MarkedConversations AS (
+    SELECT
+        *,
+        CASE
+            WHEN LAG(fluxo, 2) OVER(PARTITION BY conversation_name ORDER BY turn_position) != 'DA 0 - Menu da Dívida Ativa'
+                 AND LAG(fluxo) OVER(PARTITION BY conversation_name ORDER BY turn_position) = 'DA 0 - Menu da Dívida Ativa'
+            THEN 1
+            ELSE 0
+        END AS isNewPart
+    FROM
+        historico
+),
+NumberedConversations AS (
+    SELECT
+        *,
+        SUM(isNewPart) OVER(PARTITION BY conversation_name ORDER BY turn_position) AS part_number
+    FROM
+        MarkedConversations
+),
+ConversationsWithNewTurn AS (
+    SELECT
+        *,
+        ROW_NUMBER() OVER(PARTITION BY conversation_name, part_number ORDER BY turn_position) AS new_turn
+    FROM
+        NumberedConversations
+),
+new_conv_id AS (
+    SELECT
+        CONCAT(conversation_name, '-', FORMAT('%02d', part_number)) AS new_conversation_id,
+        mensagem_cidadao,
+        resposta_bot,
+        turn_position,
+        fluxo,
+        passo,
+        horario,
+        parametros,
+        request_time,
+        response,
+        new_turn,
+        conversation_name
+    FROM
+        ConversationsWithNewTurn
+),
+TypeClassification AS (
+    SELECT
+        new_conversation_id,
+        CASE
+            WHEN COUNTIF(fluxo != 'DA 0 - Menu da Dívida Ativa') = 0 THEN 'informational'
+            WHEN MAX(CASE WHEN fluxo IN ('DA 1 - Consultar Débitos Dívida Ativa Solicitar Guias Exibir Informações',
+                                         'DA 1.7. Emitir Guia de Pagamento à Vista',
+                                         'DA 1.9. Emitir Guia de Regularização de Débitos',
+                                         'DA 3 - Consulta de protestos',
+                                         'DA 5 - Cadastre-se (Serviços úteis)') THEN 1 ELSE 0 END) = 1 THEN 'service'
+            WHEN MAX(CASE WHEN fluxo IN ('DA 2 - Como parcelar minha dívida', 'DA 4 - Informações Gerais') THEN 1 ELSE 0 END) = 1 THEN 'informational'
+            ELSE 'undefined'
+        END AS type_flow
+    FROM
+        new_conv_id
+    GROUP BY
+        new_conversation_id
+)
+
+, DistinctFluxo AS (
+    SELECT DISTINCT
+        new_conversation_id,
+        fluxo
+    FROM
+        new_conv_id
+    WHERE
+        fluxo != 'DA 0 - Menu da Dívida Ativa'
+),
+
+FluxoMain AS (
+    SELECT
+        d.new_conversation_id,
+        MIN(d.fluxo) AS main_fluxo,
+        STRING_AGG(d.fluxo, ', ') AS distinct_fluxo_list
+    FROM
+        DistinctFluxo d
+    GROUP BY
+        d.new_conversation_id
+),
+
+ParametrosExtracted AS (
+    SELECT
+        new_conversation_id,
+        CASE
+            WHEN JSON_VALUE(parametros, '$.api_resposta_sucesso') IS NULL THEN
+                CASE
+                    WHEN REGEXP_CONTAINS(TO_JSON_STRING(parametros), r'\"api_resposta_sucesso\"') THEN 'replaced'
+                    ELSE NULL
+                END
+            ELSE JSON_VALUE(parametros, '$.api_resposta_sucesso')
+        END AS api_resposta_sucesso,
+        CASE
+            WHEN JSON_VALUE(parametros, '$.api_descricao_erro') IS NULL THEN
+                CASE
+                    WHEN REGEXP_CONTAINS(TO_JSON_STRING(parametros), r'\"api_descricao_erro\"') THEN 'replaced'
+                    ELSE NULL
+                END
+            ELSE JSON_VALUE(parametros, '$.api_descricao_erro')
+        END AS api_descricao_erro
+    FROM
+        new_conv_id
+    WHERE
+        parametros IS NOT NULL
+),
+
+DistinctApiValues AS (
+    SELECT
+        new_conversation_id,
+        CASE
+            WHEN COUNTIF(api_resposta_sucesso = 'false') > 0 THEN 'false'
+            WHEN COUNTIF(api_resposta_sucesso = 'true') > 0 THEN 'true'
+            ELSE MAX(api_resposta_sucesso)  -- Handles 'replaced' or NULL
+        END AS api_resposta_sucesso,
+        MAX(api_descricao_erro) AS api_descricao_erro
+    FROM
+        ParametrosExtracted
+    GROUP BY
+        new_conversation_id
+),
+
+FinalTableDA AS (
+    SELECT
+        n.*,
+        type_flow,
+        IFNULL(f.main_fluxo, 'DA 0 - Menu da Dívida Ativa') AS main_fluxo,
+        a.api_resposta_sucesso,
+        a.api_descricao_erro
+    FROM
+        new_conv_id n
+    JOIN
+        TypeClassification t ON n.new_conversation_id = t.new_conversation_id
+    LEFT JOIN
+        FluxoMain f ON n.new_conversation_id = f.new_conversation_id
+    LEFT JOIN
+        DistinctApiValues a ON n.new_conversation_id = a.new_conversation_id
+    WHERE t.type_flow != 'undefined'
+)
+
+-- SELECT * FROM FinalTableDA #WHERE api_resposta_sucesso = "replaced" AND main_fluxo IN ('DA 3 - Consulta de protestos', 'DA 1 - Consultar Débitos Dívida Ativa Solicitar Guias Exibir Informações')
+-- ORDER BY new_conversation_id, new_turn;
+
+, FinalTableOutros AS (
+    # Separando fluxos de outros serviços em que o usuário começou na dívida ativa mas foi para outro serviço depois
+    SELECT
+        n.*,
+        t.type_flow,
+        f.distinct_fluxo_list
+    FROM
+        new_conv_id n
+    JOIN
+        TypeClassification t ON n.new_conversation_id = t.new_conversation_id
+    LEFT JOIN
+        FluxoMain f ON n.new_conversation_id = f.new_conversation_id
+    WHERE t.type_flow = 'undefined'
+)
+
+, primeira_interacao AS (
+  SELECT
+    new_conversation_id,
+    main_fluxo as fluxo_primeira_interacao,
+    request_time AS hora_primeira_interacao,
+    mensagem_cidadao AS primeira_mensagem,
+    JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.ambiente')) AS ambiente
+  FROM FinalTableDA
+  WHERE turn_position = 1
+)
+
+, ultima_interacao as (
+SELECT
+  new_conversation_id,
+  MAX(new_turn) as last_turn
+FROM FinalTableDA
+GROUP BY new_conversation_id
+),
+
+fim_conversas_DA AS (
+SELECT
+  hist.new_conversation_id as conversation_name,
+  JSON_VALUE(parametros, '$.usuario_cpf') AS cpf,
+  JSON_VALUE(parametros, '$.phone') as telefone,
+  CASE
+    WHEN pi.ambiente = "production" THEN "Produção"
+    ELSE "Homologação"
+  END ambiente,
+  main_fluxo as fluxo_nome,
+  horario,
+  DATETIME(request_time, "America/Buenos_Aires") as request_time,
+  ROUND(DATE_DIFF(request_time, hora_primeira_interacao, SECOND)/60,1) as duracao_minutos,
+  hist.new_turn as ultimo_turno,
+  pi.primeira_mensagem,
+  response,
+  CASE
+    WHEN hist.passo = "End Session" OR hist.fluxo = "DA 0 - Menu da Dívida Ativa" THEN true
+    ELSE false
+    END conversa_finalizada,
+#####
+  CASE
+    WHEN hist.new_turn = 1 THEN "hard_bounce"
+    WHEN
+      hist.new_turn = 2
+      AND (
+        ENDS_WITH(hist.resposta_bot, 'VOLTAR')
+        OR ENDS_WITH(hist.resposta_bot, 'SAIR')
+      )
+      THEN "timeout_usuario_pre_transacao" -- "soft_bounce"
+    WHEN
+        ENDS_WITH(hist.resposta_bot, 'VOLTAR')
+     OR ENDS_WITH(hist.resposta_bot, 'SAIR')
+     THEN "desistencia"
+    WHEN
+        (hist.type_flow = "informational" AND hist.fluxo = "DA 0 - Menu da Dívida Ativa")
+        THEN "engajado"
+    WHEN
+      (hist.type_flow = "informational" AND hist.fluxo != "DA 0 - Menu da Dívida Ativa") #timeout informacional
+      OR
+      (hist.type_flow = "service" AND hist.api_resposta_sucesso IS NULL)
+      THEN "timeout_usuario_pre_transacao"
+    -- WHEN
+    --   JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_abertura_chamado')) = "false"
+    --   OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_endereco_abertura_chamado')) = "false"
+    --   THEN "impedimento_regra_negocio"
+    WHEN
+        (hist.type_flow = "service" AND hist.api_resposta_sucesso IN ("replaced", "true"))
+        THEN "transacao_realizada"
+    WHEN
+      hist.resposta_bot IS NULL
+      THEN "timeout interno"
+    WHEN hist.type_flow = "service" THEN "timeout_usuario_pos_transacao"
+    ELSE "investigar"
+    END classificacao_conversa,
+#####
+  "sucesso" as status_final_conversa,
+  hist.passo as passo_falha,
+  hist.fluxo as fluxo_falha,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.solicitacao_retorno')) erro_abertura_ticket,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.solicitacao_protocolo')) protocolo,
+  SAFE_CAST(NULL AS INT64) AS turnos_em_menus,
+  SAFE_CAST(NULL AS INT64) AS estimativa_turnos_menu,
+  SAFE_CAST(NULL AS INT64) AS turnos_em_servico,
+  SAFE_CAST(NULL AS INT64) AS estimativa_turnos_servico,
+  SAFE_CAST(NULL AS INT64) AS turnos_em_endereco,
+  SAFE_CAST(NULL AS INT64) AS turnos_em_identificacao,
+  hist.conversation_name as conversa_completa_id,
+  SAFE_CAST(NULL AS INT64) AS conversa_completa_turnos_em_menus,
+  SAFE_CAST(NULL AS INT64) AS conversa_completa_fluxos_interagidos,
+  SAFE_CAST(NULL AS INT64) AS conversa_completa_duracao,
+  SAFE_CAST(NULL AS STRING) AS conversa_completa_ultimo_fluxo_servico,
+FROM FinalTableDA as hist
+INNER JOIN ultima_interacao as ui
+  ON hist.new_conversation_id = ui.new_conversation_id AND hist.new_turn = ui.last_turn
+INNER JOIN primeira_interacao as pi
+  ON hist.new_conversation_id = pi.new_conversation_id
+ORDER BY request_time DESC)
+
+SELECT * FROM fim_conversas_DA WHERE fluxo_nome != 'DA 0 - Menu da Dívida Ativa'

--- a/models/mart/dialogflowcx/mart__fim_conversas_macrofluxos.sql
+++ b/models/mart/dialogflowcx/mart__fim_conversas_macrofluxos.sql
@@ -1,0 +1,177 @@
+{{
+    config(
+        alias='fim_conversas_macrofluxos'
+    )
+}}
+
+WITH compilation AS (
+  SELECT
+    *
+  FROM {{ ref('mart__historico_conversas_macrofluxos') }}
+),
+
+-- SELECT * FROM compilation
+-- where
+-- #NOT ENDS_WITH(new_conversation_id, "00")
+-- STARTS_WITH(new_conversation_id, "projects/rj-chatbot-dev/locations/global/agents/29358e97-22d5-48e0-b6e0-fe32e70b67cd/environments/f288d64a-52f3-42f7-be7d-cac0b0f4957a/sessions/protocol-09700003664811")
+-- order by conversation_name, turn_position ASC
+
+primeira_interacao AS (
+  SELECT
+    new_conversation_id,
+    request_time AS hora_primeira_interacao,
+    mensagem_cidadao AS primeira_mensagem,
+    JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.intent.displayName')) as primeiro_intent,
+    JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.ambiente')) AS ambiente
+  FROM compilation
+  WHERE new_turn = 1
+)
+
+, ultima_interacao as (
+SELECT
+  new_conversation_id,
+  MAX(new_turn) as last_turn
+FROM compilation
+GROUP BY new_conversation_id
+)
+
+, penultimo_turno_0 as (
+SELECT
+  new_conversation_id,
+  MAX(new_turn) as penultimate_turn,
+FROM compilation
+WHERE new_turn < (
+    SELECT MAX(new_turn)
+    FROM compilation AS c2
+    WHERE c2.new_conversation_id = compilation.new_conversation_id
+  )
+GROUP BY new_conversation_id
+)
+
+, penultimo_passo as (
+SELECT
+  p0.new_conversation_id,
+  penultimate_turn,
+  c.passo
+FROM penultimo_turno_0 as p0
+INNER JOIN compilation as c
+  ON p0.penultimate_turn = c.new_turn AND p0.new_conversation_id = c.new_conversation_id
+),
+
+fim_conversas_macrofluxo AS (
+SELECT
+  hist.new_conversation_id as conversation_name,
+  JSON_VALUE(parametros, '$.usuario_cpf') AS cpf,
+  JSON_VALUE(parametros, '$.phone') as telefone,
+  CASE
+    WHEN pi.ambiente = "production" THEN "Produção"
+    ELSE "Homologação"
+  END ambiente,
+  CASE
+    WHEN hist.nome_servico_1746 = "Serviço Não Mapeado"
+      THEN CONCAT("Menu ", JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.macrotema')))
+    ELSE hist.nome_servico_1746 END as fluxo_nome,
+  horario,
+  DATETIME(request_time, "America/Buenos_Aires") as request_time,
+  ROUND(DATE_DIFF(request_time, hora_primeira_interacao, SECOND)/60,1) as duracao_minutos,
+  hist.new_turn as ultimo_turno,
+  pi.primeira_mensagem,
+  response,
+  CASE
+    WHEN hist.passo = "End Session" OR pi.primeiro_intent = "voltar_inicio_padrao" THEN true
+    ELSE false
+    END conversa_finalizada,
+#####
+  CASE
+    WHEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.solicitacao_protocolo')) IS NOT NULL THEN "chamado_aberto"
+    WHEN hist.turn_position = 1 THEN "hard_bounce"
+    WHEN
+        -- hist.turn_position > 2
+        (hist.nome_servico_1746 IN ("Serviço Não Mapeado")
+          AND hist.fluxo = "CadÚnico")
+        OR
+        (hist.nome_servico_1746 IN ("CadÚnico", "Matrícula Municipal"))
+        THEN "engajado"
+    WHEN
+      JSON_VALUE(JSON_EXTRACT(hist.response, '$.queryResult.intent.displayName')) = "encerra_sessao_padrao"
+      AND hist.codigo_servico_1746 IS NULL
+      THEN "soft_bounce"
+    WHEN
+      (JSON_VALUE(JSON_EXTRACT(hist.response, '$.queryResult.intent.displayName')) = "voltar_inicio_padrao"
+      OR JSON_VALUE(JSON_EXTRACT(hist.response, '$.queryResult.intent.displayName')) = "encerra_sessao_padrao")
+      AND hist.codigo_servico_1746 IS NOT NULL
+      THEN "desistência"
+    WHEN
+      JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.solicitacao_retorno')) = "erro_interno_timeout"
+      THEN "timeout SGRC"
+    WHEN ENDS_WITH(resposta_bot,'TRANSBORDO') THEN "transbordo"
+    WHEN
+      # Casos em que o Chatbot identificou a inelegibilidade
+      (JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_abertura_chamado_justificativa')) != "erro_desconhecido"
+      AND
+      (JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_abertura_chamado')) = "false"
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_endereco_abertura_chamado')) = "false")
+      )
+      # Casos em que o SGRC identificou a inelegibilidade
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_abertura_chamado_justificativa')) = "chamado_aberto"
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_abertura_chamado_justificativa')) = "chamado_fechado_12_dias"
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_endereco_abertura_chamado_justificativa')) = "chamado_aberto"
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_endereco_abertura_chamado_justificativa')) = "chamado_fechado_12_dias"
+      THEN "impedimento_regra_negocio"
+    WHEN
+      resposta_bot IS NULL
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.solicitacao_retorno')) = "erro_interno"
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_endereco_abertura_chamado_justificativa')) = "erro_desconhecido"
+      OR JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.rebi_elegibilidade_abertura_chamado_justificativa')) = "erro_desconhecido"
+      THEN "timeout interno"
+    WHEN
+      ENDS_WITH(resposta_bot, 'SAIR')
+      OR hist.passo = "Finalizar Atendimento"
+      OR pen.passo = "Finalizar Atendimento"  -- Verificação do penúltimo turno
+      THEN "engajado"
+    WHEN
+      hist.codigo_servico_1746 IS NOT NULL
+      OR hist.nome_servico_1746 != "Serviço Não Mapeado"
+      THEN "timeout_usuario_pos_transacao"
+    WHEN
+      hist.codigo_servico_1746 IS NULL
+      THEN "timeout_usuario_pre_transacao" -- "soft_bounce"
+    ELSE  "nao_classificado"
+    END classificacao_conversa,
+#####
+  "sucesso" as status_final_conversa,
+  hist.passo as passo_falha,
+  hist.fluxo as fluxo_falha,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.solicitacao_retorno')) erro_abertura_ticket,
+  JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.solicitacao_protocolo')) protocolo,
+  CASE
+    WHEN hist.turns_until_service = 0
+      THEN hist.new_turn
+    ELSE hist.turns_until_service END as turnos_em_menus,
+  hist.estimativa_turnos_menu,
+  hist.new_turn - hist.turnos_em_endereco - hist.turnos_em_identificacao -
+    (CASE
+      WHEN hist.turns_until_service = 0
+        THEN hist.new_turn
+      ELSE hist.turns_until_service END) as turnos_em_servico,
+  hist.estimativa_turnos_servico,
+  hist.turnos_em_endereco,
+  hist.turnos_em_identificacao,
+  hist.conversation_name as conversa_completa_id,
+  CASE
+    WHEN hist.conversa_completa_turnos_em_menus = 0
+      THEN hist.conversa_completa_duracao
+    ELSE hist.conversa_completa_turnos_em_menus END as conversa_completa_turnos_em_menus,
+  hist.conversa_completa_fluxos_interagidos,
+  hist.conversa_completa_duracao,
+  hist.conversa_completa_ultimo_fluxo_servico
+FROM compilation as hist
+INNER JOIN ultima_interacao as ui
+  ON hist.new_conversation_id = ui.new_conversation_id AND hist.new_turn = ui.last_turn
+INNER JOIN primeira_interacao as pi
+  ON hist.new_conversation_id = pi.new_conversation_id
+LEFT JOIN penultimo_passo AS pen
+  ON hist.new_conversation_id = pen.new_conversation_id -- Junta com o penúltimo turno
+)
+
+SELECT * FROM fim_conversas_macrofluxo

--- a/models/mart/dialogflowcx/mart__historico_conversas_legivel.sql
+++ b/models/mart/dialogflowcx/mart__historico_conversas_legivel.sql
@@ -1,0 +1,65 @@
+{{
+    config(
+        alias='historico_conversas_legivel'
+    )
+}}
+
+WITH historico_padrao AS (
+  select
+    h.conversation_name as conversa_completa_id,
+    h.turn_position as conversa_completa_turn_position,
+    h.conversation_name,
+    h.turn_position,
+    JSON_VALUE(JSON_EXTRACT(h.response, '$.queryResult.text')) as mensagem_cidadao,
+    JSON_VALUE(JSON_EXTRACT(h.derived_data, '$.agentUtterances')) as resposta_bot,
+    FORMAT_DATETIME("%d/%m/%Y às %H:%M", DATETIME(h.request_time, "America/Buenos_Aires")) as horario,
+    JSON_EXTRACT(h.response, '$.queryResult.parameters') as parametros,
+    h.request_time,
+    h.response
+  from `rj-chatbot-dev.dialogflowcx.historico_conversas` as h
+  LEFT JOIN (
+    SELECT
+      conversation_name,
+      turn_position,
+      COUNT(*) AS contagem
+    FROM rj-chatbot-dev.dialogflowcx.historico_conversas
+    GROUP BY conversation_name, turn_position
+    HAVING COUNT(*) > 1
+  ) AS bc
+    ON h.conversation_name = bc.conversation_name
+  WHERE bc.conversation_name IS NULL -- Remove conversations with more than one conversation where turn_position = 1, probably bot cases
+),
+
+historico_macrofluxo AS (
+  SELECT
+    conversation_name as conversa_completa_id,
+    turn_position as conversa_completa_turn_position,
+    new_conversation_id as conversation_name,
+    new_turn as turn_position,
+    mensagem_cidadao,
+    resposta_bot,
+    horario,
+    parametros,
+    request_time,
+    response
+  FROM {{ ref('mart__historico_conversas_macrofluxos') }}
+)
+
+-- Combine rows where conversation_name does not exist in the other table
+(
+  SELECT hp.*
+  FROM historico_padrao hp
+  LEFT JOIN historico_macrofluxo hm
+    ON hp.conversation_name = hm.conversation_name
+  WHERE hm.conversation_name IS NULL
+
+  UNION ALL
+
+  SELECT hm.*
+  FROM historico_macrofluxo hm
+  LEFT JOIN historico_padrao hp
+    ON hm.conversation_name = hp.conversation_name
+  WHERE hp.conversation_name IS NULL
+)
+
+ORDER BY conversation_name, request_time ASC

--- a/models/mart/dialogflowcx/mart__historico_conversas_macrofluxos.sql
+++ b/models/mart/dialogflowcx/mart__historico_conversas_macrofluxos.sql
@@ -1,0 +1,317 @@
+{{
+    config(
+        alias='historico_conversas_macrofluxos'
+    )
+}}
+
+WITH marked_conversations AS (
+  WITH filtro_macrofluxos AS (
+    SELECT DISTINCT
+        h.conversation_name
+    FROM rj-chatbot-dev.dialogflowcx.historico_conversas as h
+    LEFT JOIN (
+      SELECT
+        conversation_name,
+        turn_position,
+        COUNT(*) AS contagem
+      FROM rj-chatbot-dev.dialogflowcx.historico_conversas
+      GROUP BY conversation_name, turn_position
+      HAVING COUNT(*) > 1
+    ) AS bc
+      ON h.conversation_name = bc.conversation_name
+    WHERE
+        h.turn_position = 1
+        AND
+        (
+          JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) IN (
+              "Cuidados com a Cidade",
+              "Educação, Saúde e Cidadania",
+              "Servidor Público",
+              "Suporte Técnico",
+              "Trânsito e Transportes",
+              "Trânsito",
+              "Transportes",
+              "Tributos e Licenciamento"
+          )
+          OR
+          (
+            JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentPage.displayName')) = 'Menu Principal'
+            AND request_time >= '2024-08-02'
+          )
+          OR
+          (
+            JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.match.matchType')) = "PLAYBOOK"
+          )
+        )
+        AND bc.conversation_name IS NULL
+  ), --travazap filter
+
+  historico AS (
+      SELECT
+          h.conversation_name,
+          JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.text')) AS mensagem_cidadao,
+          JSON_VALUE(JSON_EXTRACT(derived_data, '$.agentUtterances')) AS resposta_bot,
+          turn_position,
+          JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentFlow.displayName')) AS fluxo,
+          JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.currentPage.displayName')) AS passo,
+          JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.codigo_servico_1746')) AS codigo_servico_1746,
+          JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.macrotema')) AS macrotema,
+          `rj-chatbot-dev.dialogflowcx`.get_service_data(JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.codigo_servico_1746'))) AS service_data_array,
+          FORMAT_DATETIME("%d/%m/%Y às %H:%M", DATETIME(request_time, "America/Buenos_Aires")) AS horario,
+          JSON_EXTRACT(response, '$.queryResult.parameters') AS parametros,
+          request_time,
+          response,
+          ROW_NUMBER() OVER (PARTITION BY h.conversation_name, h.turn_position ORDER BY request_time DESC) AS row_num
+      FROM rj-chatbot-dev.dialogflowcx.historico_conversas AS h
+      INNER JOIN filtro_macrofluxos AS f
+          ON f.conversation_name = h.conversation_name
+      -- Remove o ORDER BY aqui e adicione apenas onde for necessário
+  ),
+
+  historico_with_lag AS (
+    SELECT
+      *,
+      LAG(codigo_servico_1746) OVER(PARTITION BY conversation_name ORDER BY turn_position) AS lag_codigo_servico_1746_1,
+      LAG(codigo_servico_1746, 2) OVER(PARTITION BY conversation_name ORDER BY turn_position) AS lag_codigo_servico_1746_2
+    FROM historico
+    WHERE row_num = 1 #fitro para garantir apenas 1 linha por par (conversation_name, turn_position)
+  ),
+
+  MarkedConversations AS (
+      SELECT
+          * EXCEPT(service_data_array),
+          CASE
+            WHEN service_data_array[OFFSET(0)] = "Serviço não mapeado"
+            THEN JSON_VALUE(JSON_EXTRACT(response, '$.queryResult.parameters.servico_1746_descricao'))
+            ELSE service_data_array[OFFSET(0)] END AS nome_servico_1746,
+          service_data_array[OFFSET(1)] AS estimativa_turnos_servico,
+          service_data_array[OFFSET(2)] AS estimativa_turnos_menu,
+          CASE
+              WHEN lag_codigo_servico_1746_2 IS NOT NULL AND codigo_servico_1746 IS NULL THEN 1
+              WHEN lag_codigo_servico_1746_1 IS NOT NULL AND lag_codigo_servico_1746_1 != codigo_servico_1746 THEN 1
+              WHEN lag_codigo_servico_1746_2 IS NOT NULL AND lag_codigo_servico_1746_1 IS NULL AND codigo_servico_1746 IS NOT NULL THEN 1
+              WHEN lag_codigo_servico_1746_1 IS NULL AND codigo_servico_1746 IS NOT NULL THEN 0
+              ELSE 0
+          END AS isNewPart
+      FROM historico_with_lag
+  )
+
+  SELECT
+    *
+  FROM MarkedConversations
+),
+
+NumberedConversations AS (
+    SELECT
+        conversation_name,
+        turn_position,
+        fluxo,
+        codigo_servico_1746,
+        nome_servico_1746,
+        estimativa_turnos_servico,
+        estimativa_turnos_menu,
+        SUM(isNewPart) OVER(PARTITION BY conversation_name ORDER BY turn_position) AS part_number
+    FROM
+        marked_conversations
+),
+ConversationsWithNewTurn AS (
+    SELECT
+        conversation_name,
+        turn_position,
+        part_number,
+        fluxo,
+        codigo_servico_1746,
+        nome_servico_1746,
+        estimativa_turnos_servico,
+        estimativa_turnos_menu,
+        ROW_NUMBER() OVER(PARTITION BY conversation_name, part_number ORDER BY turn_position) AS new_turn
+    FROM
+        NumberedConversations
+),
+new_conv_id AS (
+    SELECT
+        CONCAT(conversation_name, '-', FORMAT('%02d', part_number)) AS new_conversation_id,
+        #mensagem_cidadao,
+        #resposta_bot,
+        turn_position,
+        #macrotema,
+        fluxo,
+        #passo,
+        codigo_servico_1746,
+        nome_servico_1746,
+        estimativa_turnos_servico,
+        estimativa_turnos_menu,
+        #horario,
+        #parametros,
+        #request_time,
+        #response,
+        new_turn,
+        conversation_name
+    FROM
+        ConversationsWithNewTurn
+),
+
+service_names AS (
+    SELECT
+        new_conversation_id,
+        CASE
+            WHEN COUNT(DISTINCT nome_servico_1746) = 1 THEN MAX(nome_servico_1746)
+            WHEN COUNT(DISTINCT nome_servico_1746) = 2 AND MAX(nome_servico_1746) = 'Serviço não mapeado' THEN MIN(nome_servico_1746)
+            WHEN COUNT(DISTINCT nome_servico_1746) = 2 AND MIN(nome_servico_1746) = 'Serviço não mapeado' THEN MAX(nome_servico_1746)
+            ELSE CONCAT('Conversa com mais de um fluxo: ', STRING_AGG(DISTINCT nome_servico_1746, ', '))
+        END AS nome_servico,
+        MAX(SAFE_CAST(estimativa_turnos_servico AS INT64)) as estimativa_turnos_servico,
+        MAX(SAFE_CAST(estimativa_turnos_menu AS INT64)) as estimativa_turnos_menu
+    FROM
+        new_conv_id
+    GROUP BY
+        new_conversation_id
+),
+
+first_service_turn AS (
+    SELECT
+        new_conversation_id,
+        MIN(new_turn) AS first_service_turn_position
+    FROM
+        new_conv_id
+    WHERE
+        codigo_servico_1746 IS NOT NULL
+    GROUP BY
+        new_conversation_id
+),
+
+compilation_0 AS (
+SELECT
+    n.new_conversation_id,
+    #INITCAP(n.macrotema) as macrotema,
+    CASE
+      WHEN LOWER(nome_servico) LIKE "%matricula%"
+        OR LOWER(nome_servico) LIKE "%matrícula%"
+      THEN "Matrícula Municipal"
+      WHEN LOWER(nome_servico) LIKE "%cadunico%"
+        OR LOWER(nome_servico) LIKE "%cadúnico%"
+      THEN "CadÚnico"
+    ELSE INITCAP(s.nome_servico) END as nome_servico_1746,
+    #n.mensagem_cidadao,
+    #n.resposta_bot,
+    n.turn_position,
+    n.fluxo,
+    #n.passo,
+    n.codigo_servico_1746,
+    #n.horario,
+    #n.parametros,
+    #n.request_time,
+    #n.response,
+    n.new_turn,
+    n.conversation_name,
+    COALESCE(f.first_service_turn_position - 1, 0) AS turns_until_service,
+    CASE WHEN n.fluxo = "Coleta Endereço" THEN true ELSE false END AS address_turn,
+    CASE WHEN n.fluxo = "Identificação" THEN true ELSE false END AS identification_turn,
+    s.estimativa_turnos_servico,
+    s.estimativa_turnos_menu
+FROM new_conv_id as n
+LEFT JOIN service_names as s
+    ON n.new_conversation_id = s.new_conversation_id
+LEFT JOIN first_service_turn as f
+    ON n.new_conversation_id = f.new_conversation_id
+),
+
+conversas_completas_metrics AS (
+  SELECT
+    c0.conversation_name,
+    MAX(sq.turns_per_service) AS conversa_completa_turnos_em_menus,
+    COUNT(DISTINCT c0.nome_servico_1746) AS conversa_completa_fluxos_interagidos,
+    COUNT(CASE WHEN address_turn IS true THEN 1 ELSE NULL END) as conversa_completa_fluxos_endereco,
+    COUNT(CASE WHEN identification_turn IS true THEN 1 ELSE NULL END) as conversa_completa_fluxos_identificacao
+  FROM compilation_0 as c0
+  INNER JOIN
+  (SELECT conversation_name, SUM(turns_per_service) as turns_per_service FROM
+    (
+      SELECT
+        conversation_name,
+        new_conversation_id,
+        MAX(turns_until_service) AS turns_per_service,
+      FROM
+        compilation_0
+      GROUP BY 1,2
+    ) GROUP BY 1
+  ) AS sq
+  ON c0.conversation_name = sq.conversation_name
+  GROUP BY
+    conversation_name
+),
+
+conversas_completas_last_service AS (
+  SELECT
+    c.conversation_name,
+    c.nome_servico_1746 AS ultimo_fluxo_servico,
+    ltp.last_turn_position
+  FROM
+    compilation_0 as c
+  INNER JOIN
+    (
+      SELECT
+        conversation_name,
+        MAX(turn_position) AS last_turn_position
+      FROM
+        compilation_0
+      GROUP BY
+        conversation_name
+    ) as ltp
+    ON c.conversation_name = ltp.conversation_name AND c.turn_position = ltp.last_turn_position
+),
+
+conversas_completas AS (
+  SELECT
+    m.conversation_name,
+    m.conversa_completa_turnos_em_menus,
+    m.conversa_completa_fluxos_interagidos,
+    m.conversa_completa_fluxos_endereco,
+    m.conversa_completa_fluxos_identificacao,
+    l.last_turn_position,
+    l.ultimo_fluxo_servico
+  FROM
+    conversas_completas_metrics m
+  LEFT JOIN
+    conversas_completas_last_service l
+  ON
+    m.conversation_name = l.conversation_name
+),
+
+turnos_em_identificacao_e_endereco AS (
+  SELECT
+      new_conversation_id,
+      COUNT(CASE WHEN address_turn IS true THEN 1 ELSE NULL END) as turnos_em_endereco,
+      COUNT(CASE WHEN identification_turn IS true THEN 1 ELSE NULL END) as turnos_em_identificacao
+  FROM compilation_0
+  GROUP BY 1
+),
+
+compilation AS (
+  SELECT
+    c.*,
+    INITCAP(n.macrotema) as macrotema,
+    n.mensagem_cidadao,
+    n.resposta_bot,
+    n.passo,
+    n.horario,
+    n.parametros,
+    n.request_time,
+    n.response,
+    tie.turnos_em_endereco,
+    tie.turnos_em_identificacao,
+    cc.conversa_completa_turnos_em_menus,
+    cc.conversa_completa_fluxos_interagidos,
+    cc.last_turn_position as conversa_completa_duracao,
+    cc.ultimo_fluxo_servico as conversa_completa_ultimo_fluxo_servico
+  FROM compilation_0 as c
+  LEFT JOIN conversas_completas as cc
+    ON c.conversation_name = cc.conversation_name
+  LEFT JOIN turnos_em_identificacao_e_endereco as tie
+    ON c.new_conversation_id = tie.new_conversation_id
+  INNER JOIN
+    (SELECT * FROM marked_conversations) as n
+    ON c.conversation_name = n.conversation_name AND c.turn_position = n.turn_position
+)
+
+SELECT * from compilation


### PR DESCRIPTION
Migrando os modelos dbts dialogflowcx para a estrutura atual. 

Segue o link de referência: https://github.com/prefeitura-rio/pipelines_rj_escritorio/blob/9bf7cd1bfdbde4846838094222a6b096d7c6291b/pipelines/chatbot/dbt_chatbot_metricas/schedules.py#L27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * Adicionados modelos analíticos para consolidar conversas do Dialogflow CX.
  * Disponibilizado histórico de conversas em formato legível, com mensagens, respostas, horários e parâmetros.
  * Incluídas métricas de duração, turnos, fluxos, encerramento, falhas, satisfação e status.
  * Aprimorado o acompanhamento de conversas sobre dívida ativa, macrofluxos e mudanças de serviço.
  * Conversas duplicadas e registros inválidos são filtrados para melhorar a qualidade dos dados.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->